### PR TITLE
fix: Github에서만 동작 하도록 로직 수정

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -21,7 +21,7 @@ const manifest: chrome.runtime.ManifestV3 = {
   },
   content_scripts: [
     {
-      matches: ["http://*/*", "https://*/*", "<all_urls>"],
+      matches: ["*://*.github.com/*"],
       js: ["src/pages/content/index.js"],
       // KEY for cache invalidation
       css: ["assets/css/contentStyle<KEY>.chunk.css"],

--- a/src/pages/background/index.ts
+++ b/src/pages/background/index.ts
@@ -13,7 +13,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     sendResponse({ received: true });
     return true;
   }
-  sendResponse({
-    received: true,
-  });
+  if (request.message === "APPROVE_PR") {
+    sendResponse({ received: true });
+    return true;
+  }
+  if (request.message === "READY") {
+    sendResponse({ received: true });
+    return true;
+  }
 });

--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -23,18 +23,22 @@ const fetchPRListFromPage = async (): Promise<
 };
 
 if (window.location.hostname === "github.com") {
-  chrome.runtime.onMessage.addListener(async (request) => {
+  chrome.runtime.onMessage.addListener((request, _, sendResponse) => {
+    if (request.message === "READY") {
+      sendResponse({ code: 200, data: true });
+      return true;
+    }
     if (request.message === "GET_PR_LIST") {
-      const prList = await fetchPRListFromPage();
-      chrome.runtime.sendMessage({
-        code: 200,
-        message: "PR_LIST",
-        data: prList,
-      });
+      (async () => {
+        if (request.message === "GET_PR_LIST") {
+          const prList = await fetchPRListFromPage();
+          sendResponse({ code: 200, data: prList });
+        }
+      })();
       return true;
     }
     if (request.message === "APPROVE_PR") {
-      await approvePR(request.data.issueNumber);
+      approvePR(request.data.issueNumber);
       chrome.runtime.sendMessage({ code: 200, message: "APPROVED" });
     }
     return true;


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #9 
- PR의 메인 내용

- [x] github 페이지에서만 동작 하도록 수정

<br>

## 🔨 작업 사항 (필수)

1. github 페이지에서만 동작하도록 mainfest 수정
2. sendResponse callback을 통해 메시징 처리 하도록 로직 수정

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
